### PR TITLE
Userprofile post history bugfix (Issue #75)

### DIFF
--- a/frontend/src/features/Userprofile/Userprofile.tsx
+++ b/frontend/src/features/Userprofile/Userprofile.tsx
@@ -19,6 +19,7 @@ const Userprofile = () => {
   const [tabIndex, setTabIndex] = useState(0);
 
   const { username } = useParams();
+
   if (!username) {
     throw new Error("No username provided in URL.");
   }

--- a/frontend/src/hooks/useQueryUserProfileData.ts
+++ b/frontend/src/hooks/useQueryUserProfileData.ts
@@ -1,7 +1,13 @@
+import { useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import { GET_USER_DATA } from "../api/graphQL/queries/user";
 
 const useQueryUserProfileData = (username: string) => {
+  // See Issue #75 for explanation of this useEffect
+  useEffect(() => {
+    refetch();
+  }, [username]);
+
   const { data, loading, refetch } = useQuery(GET_USER_DATA, {
     variables: { username },
     notifyOnNetworkStatusChange: true,


### PR DESCRIPTION
Fix bug, where profile history was not updated if viewing two profiles after each other.