### PR TITLE
Add missing CSRFtoken header and  cookie to Apollo requests (Issue #88)

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -28,7 +28,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get('SKTCH_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('SKTCH_DEBUG', 'True').lower() == 'true'
+IS_PRODUCTION = os.environ.get('SKTCH_ENV', 'development') == 'production'
+DEBUG = os.environ.get('SKTCH_DEBUG', 'False' if IS_PRODUCTION else 'True').lower() == 'true'
 
 ALLOWED_HOSTS = os.environ.get('SKTCH_ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
 
@@ -153,7 +154,34 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = "users.User"
 
-CORS_ALLOWED_ORIGINS = os.environ.get('SKTCH_CORS_ALLOWED_ORIGINS', 'http://localhost:3000').split(',')
+# Because in a development environment the frontend and backend are served on different ports,
+# we need to set the CSRF_COOKIE_SAMESITE to 'Lax' in order to allow the frontend to send
+# cookies to the backend. In production, the frontend and backend are served on the same domain,
+# so we can set the CSRF_COOKIE_SAMESITE to 'Strict'.
+# Also, if you're accessing the frontend on localhost, make sure that the link in .env.development
+# is set to http://localhost:8000. Otherwise, if it's set to http://127.0.0.1:8000, you're going to spend 
+# hours debugging why the CSRF cookie is not being sent to the backend when you have everything set up correctly,
+# and you'll think about switching careers to be a tram driver instead.
+CSRF_COOKIE_SAMESITE = 'Strict' if IS_PRODUCTION else 'Lax'
+CSRF_TRUSTED_ORIGINS = os.environ.get('SKTCH_CSRF_TRUSTED_ORIGINS', 'http://localhost:5173,http://localhost:8000').split(',')
+
+CORS_ALLOWED_ORIGINS = os.environ.get('SKTCH_CORS_ALLOWED_ORIGINS', 'http://localhost:5173,http://localhost:8000').split(',')
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_HEADERS = [
+    'content-type',
+    'x-csrftoken',
+    'csrftoken',
+    'authorization',
+]
+CORS_ALLOW_METHODS = [
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",  # Make sure OPTIONS is allowed for preflight
+]
+
 
 # Settings for paths
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from django.http import HttpResponse
 from django.utils._os import safe_join
 from django.views.static import serve as static_serve
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 logger = logging.getLogger(__name__)
 
 
+@ensure_csrf_cookie
 def serve_react(request, path, document_root=None):
     logging.info("Serving static file: %s", path)
     path = posixpath.normpath(path).lstrip("/")

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,2 @@
+VITE_BACKEND_URL=http://localhost:8000
+VITE_BACKEND_GRAPHQL_URL=http://localhost:8000/graphql

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -18,6 +18,17 @@ import App from "./App.tsx";
 import "bootstrap/dist/css/bootstrap.css";
 import "./css/index.css";
 
+// Read the CSRF Token from the cookie. 
+const getCSRFToken = (): string => {
+  const name = "csrftoken";
+  const cookies = document.cookie.split("; ");
+  for (let cookie of cookies) {
+    const [key, value] = cookie.split("=");
+    if (key === name) return value;
+  }
+  return "";
+};
+
 // Error-handler, when the grapQL API returns an error,
 // we're going to display the user-friendly message to the user
 // in a toast and log the details to the console.
@@ -35,6 +46,9 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 
 const uploadLink = createUploadLink({
   uri: import.meta.env.VITE_BACKEND_GRAPHQL_URL,
+  headers: {
+    "X-CSRFToken": getCSRFToken(),
+  }
 });
 
 const link = from([errorLink, uploadLink]);


### PR DESCRIPTION
- Make sure when serving the React index.html file, we set the csrftoken cookie through the response.
- Add X-CSRFtoken header and include cookies with every apollo request.
- Modify VITE_BACKEND_URL and VITE_BACKEND_GRAPHQL_URL to use localhost instead of 127.0.0.1.
  - This was needed, because the csrftoken cookie was not sent in a development environment, when the frontend ran on localhost:5173 and the requested backend was 127.0.0.1:8000, because it sensed it as a cross-domain request. 
- Set up CORS and CSRF settings to both be secure in production, but still work in development.
